### PR TITLE
Updated documentation link to latest link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 Shortcuts:
 * Clarizen API: https://api.clarizen.com/V2.0/services/
-* Clarizen's API documentation: http://usermanual.clarizen.com/rest-api-guide
 * Nuget package: https://www.nuget.org/packages/Ekin.Clarizen/
 
 Table of Contents:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 Shortcuts:
 * Clarizen API: https://api.clarizen.com/V2.0/services/
+* Clarizen's API documentation: https://success.clarizen.com/hc/en-us/articles/205711828-REST-API-Guide-Version-2
 * Nuget package: https://www.nuget.org/packages/Ekin.Clarizen/
 
 Table of Contents:


### PR DESCRIPTION
Removed user guide link(http://usermanual.clarizen.com/rest-api-guide) which no longer exists.